### PR TITLE
Modal Improvements: Add larger size for wide/grid modals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ginger-tek/picovue",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ginger-tek/picovue",
-      "version": "2.3.0",
+      "version": "2.3.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "vue": "^3.5.13"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ginger-tek/picovue",
   "description": "Pico CSS 2 + Vue 3",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "dist/picovue.global.js",
   "exports": {
     "./*": "./src/*"

--- a/src/PvModal.vue
+++ b/src/PvModal.vue
@@ -54,3 +54,23 @@ onMounted(() => modal.value.addEventListener('close', handleClose))
     </article>
   </dialog>
 </template>
+
+<style scoped>
+@media (min-width: 900px) {
+  dialog.large>article {
+    max-width: 860px;
+  }
+}
+
+@media (min-width: 1080px) {
+  dialog.large>article {
+    max-width: 1000px;
+  }
+}
+
+@media (min-width: 1400px) {
+  dialog.large>article {
+    max-width: 1200px;
+  }
+}
+</style>


### PR DESCRIPTION
Add larger size for modals with wider content than the standard max-width Pico provides, especially for modals that contain grids to allow for better spacing